### PR TITLE
Add ZF metadata to module manifest

### DIFF
--- a/module/ZeroFailed.Build.DotNet.psd1
+++ b/module/ZeroFailed.Build.DotNet.psd1
@@ -90,7 +90,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+        Tags = @("ZeroFailed")
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/zerofailed/ZeroFailed.Build.DotNet/blob/main/LICENSE'
@@ -114,6 +114,18 @@ PrivateData = @{
         ExternalModuleDependencies = @()
 
     } # End of PSData hashtable
+
+    # ZeroFailed metadata
+    ZeroFailed = @{
+        ExtensionDependencies = @(
+            @{
+                # Assume latest stable version
+                Name = "ZeroFailed.Build.Common"
+                GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.Common"
+                Process = "tasks/build.process.ps1"
+            }
+        )
+    }
 
 } # End of PrivateData hashtable
 


### PR DESCRIPTION
This is now the preferred way for extensions to declare their dependencies (see https://github.com/zerofailed/ZeroFailed/pull/6)