### PR TITLE
Add DotNetCoverageSettingsFile property for -s flag support

### DIFF
--- a/module/tasks/test.properties.ps1
+++ b/module/tasks/test.properties.ps1
@@ -10,6 +10,9 @@ $SkipDotNetTests ??= [Convert]::ToBoolean((property ZF_BUILD_DOTNET_SKIP_TESTS $
 # Synopsis: Allows arbitrary arguments to be passed to 'dotnet test'.
 $AdditionalTestArgs ??= @()
 
+# Synopsis: Optional path to a dotnet-coverage settings file. When set, it will be passed to 'dotnet-coverage collect' via '-s'.
+$DotNetCoverageSettingsFile ??= ""
+
 # Synopsis: Optionally specify the target framework moniker to use when running tests.
 $TargetFrameworkMoniker ??= ""
 

--- a/module/tasks/test.tasks.ps1
+++ b/module/tasks/test.tasks.ps1
@@ -83,6 +83,10 @@ task RunTestsWithDotNetCoverage -If {$SolutionToBuild} {
         "-o", $coverageOutput
         "-f", "cobertura"
     )
+    if ($DotNetCoverageSettingsFile -and (Test-Path $DotNetCoverageSettingsFile)) {
+        Write-Build Green "Using dotnet-coverage settings file: $DotNetCoverageSettingsFile"
+        $dotnetCoverageArgs += @("-s", $DotNetCoverageSettingsFile)
+    }
 
     # Ensure the dotnet-coverage global tool is installed, as we need it to collect the code coverage data
     Install-DotNetTool -Name "dotnet-coverage" -Global


### PR DESCRIPTION
## Summary

Adds a `DotNetCoverageSettingsFile` property that, when set, passes a settings file to `dotnet-coverage collect` via the `-s` flag. This enables instrumentation-time filtering of which assemblies and source files are included in coverage collection.

## Problem

Without this, `dotnet-coverage` instruments **all** assemblies in the process (tests, NuGet packages, MTP assemblies), inflating raw Cobertura XML. Post-collection filtering via `reportgenerator` still works but cannot exclude source-level patterns (generated code, polyfills, etc.).

## Changes

- `test.properties.ps1`: Added `DotNetCoverageSettingsFile` property (defaults to empty string)
- `test.tasks.ps1`: When the property is set and the file exists, adds `-s <path>` to `dotnet-coverage collect` args

## Usage

In a project's `.zf/config.ps1`:
```powershell
$DotNetCoverageSettingsFile = (Resolve-Path (Join-Path $here ".." "dotnet-coverage.settings.xml")).Path
```

Resolves #8