### PR TITLE
fix: promote _fileLoggerProps to script scope and qualify List type

### DIFF
--- a/module/functions/_GenerateTestReport.ps1
+++ b/module/functions/_GenerateTestReport.ps1
@@ -73,7 +73,7 @@ function _GenerateTestReport {
         Write-Warning "No code coverage reports found for the file pattern '$testReportGlob' - skipping test report"
     }
     else {
-        $reportGeneratorArgs = [List[string]]::new()
+        $reportGeneratorArgs = [System.Collections.Generic.List[string]]::new()
         $reportGeneratorArgs.AddRange([string[]]@(
             "-reports:$testReportGlob",
             "-targetdir:$OutputPath",

--- a/module/tasks/test.tasks.ps1
+++ b/module/tasks/test.tasks.ps1
@@ -56,7 +56,7 @@ task RunTestsWithDotNetCoverage -If {$SolutionToBuild} {
     }
 
     # Evaluate the file logger properties so we can pass them to 'dotnet test'
-    $_fileLoggerProps = Resolve-Value $DotNetTestFileLoggerProps
+    $script:_fileLoggerProps = Resolve-Value $DotNetTestFileLoggerProps
 
     # Setup the arguments we need to pass to 'dotnet test'
     $dotnetTestArgs = @(


### PR DESCRIPTION
## Summary
- Fixes #21: `$script:_fileLoggerProps` was never written at module scope — file-logger args were always `$null`
- Fixes #20: `[List[string]]::new()` threw `TypeNotFound` due to missing `using namespace System.Collections.Generic`

## Changes
- `module/tasks/test.tasks.ps1`: Changed `$_fileLoggerProps =` to `$script:_fileLoggerProps =` so helper functions can read it
- `module/functions/_GenerateTestReport.ps1`: Changed `[List[string]]` to `[System.Collections.Generic.List[string]]` to avoid the missing `using namespace`

## Test plan
- [ ] Pester module tests pass
- [ ] CI build passes

🤖 Generated with Claude Code